### PR TITLE
Update rest-client dependency to allow any version from 2.0.x to 2.1.x and increment version number

### DIFF
--- a/facebook-leads.gemspec
+++ b/facebook-leads.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rest-client', '~> 2.0.0', '>= 2.0.0'
+  spec.add_runtime_dependency 'rest-client', '>= 2.0.0', '< 2.2'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/facebook/leads/version.rb
+++ b/lib/facebook/leads/version.rb
@@ -1,5 +1,5 @@
 module Facebook
   module Leads
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
rest-client 2.1.0 is out with important updates and is compatible.